### PR TITLE
Add Android app for scheduling app launches

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example.applaunchscheduler'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId 'com.example.applaunchscheduler'
+        minSdk 26
+        targetSdk 33
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add ProGuard rules here if needed

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.applaunchscheduler">
+
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@android:drawable/ic_dialog_alert"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".LaunchMonitorService"
+            android:exported="false" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/applaunchscheduler/BootReceiver.java
+++ b/app/src/main/java/com/example/applaunchscheduler/BootReceiver.java
@@ -1,0 +1,14 @@
+package com.example.applaunchscheduler;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            context.startService(new Intent(context, LaunchMonitorService.class));
+        }
+    }
+}

--- a/app/src/main/java/com/example/applaunchscheduler/LaunchMonitorService.java
+++ b/app/src/main/java/com/example/applaunchscheduler/LaunchMonitorService.java
@@ -1,0 +1,106 @@
+package com.example.applaunchscheduler;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.app.usage.UsageEvents;
+import android.app.usage.UsageStatsManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
+
+public class LaunchMonitorService extends Service {
+
+    private Handler handler;
+    private UsageStatsManager usageStatsManager;
+    private SharedPreferences prefs;
+
+    private final Runnable checker = new Runnable() {
+        @Override
+        public void run() {
+            checkForegroundApp();
+            handler.postDelayed(this, 1000);
+        }
+    };
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        handler = new Handler(Looper.getMainLooper());
+        usageStatsManager = (UsageStatsManager) getSystemService(Context.USAGE_STATS_SERVICE);
+        prefs = getSharedPreferences("schedule", MODE_PRIVATE);
+        startForeground(1, createNotification());
+        handler.post(checker);
+    }
+
+    private Notification createNotification() {
+        String channelId = "monitor";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(channelId, "Monitor", NotificationManager.IMPORTANCE_LOW);
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            nm.createNotificationChannel(channel);
+        }
+        return new NotificationCompat.Builder(this, channelId)
+                .setContentTitle("App monitor running")
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .build();
+    }
+
+    private void checkForegroundApp() {
+        long end = System.currentTimeMillis();
+        long begin = end - 1000;
+        UsageEvents events = usageStatsManager.queryEvents(begin, end);
+        UsageEvents.Event event = new UsageEvents.Event();
+        String pkg = null;
+        while (events.hasNextEvent()) {
+            events.getNextEvent(event);
+            if (event.getEventType() == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+                pkg = event.getPackageName();
+            }
+        }
+        if (pkg != null && isRestricted(pkg)) {
+            Intent intent = new Intent(Intent.ACTION_MAIN);
+            intent.addCategory(Intent.CATEGORY_HOME);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+        }
+    }
+
+    private boolean isRestricted(String pkg) {
+        Set<String> pkgs = new HashSet<>(prefs.getStringSet("packages", new HashSet<>()));
+        if (!pkgs.contains(pkg)) return false;
+        int startMin = prefs.getInt("startMinutes", 0);
+        int endMin = prefs.getInt("endMinutes", 23 * 60 + 59);
+        Calendar cal = Calendar.getInstance();
+        int now = cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE);
+        if (startMin <= endMin) {
+            return now >= startMin && now <= endMin;
+        } else {
+            return now >= startMin || now <= endMin;
+        }
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        handler.removeCallbacks(checker);
+        super.onDestroy();
+    }
+}

--- a/app/src/main/java/com/example/applaunchscheduler/MainActivity.java
+++ b/app/src/main/java/com/example/applaunchscheduler/MainActivity.java
@@ -1,0 +1,93 @@
+package com.example.applaunchscheduler;
+
+import android.app.TimePickerDialog;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public class MainActivity extends AppCompatActivity {
+
+    private TextView startTimeView;
+    private TextView endTimeView;
+    private ArrayAdapter<String> adapter;
+    private Set<String> packages;
+    private SharedPreferences prefs;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        prefs = getSharedPreferences("schedule", MODE_PRIVATE);
+        startTimeView = findViewById(R.id.start_time);
+        endTimeView = findViewById(R.id.end_time);
+        ListView listView = findViewById(R.id.app_list);
+
+        packages = new HashSet<>(prefs.getStringSet("packages", new HashSet<>()));
+        adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, new ArrayList<>(packages));
+        listView.setAdapter(adapter);
+
+        Button addApp = findViewById(R.id.button_add_app);
+        addApp.setOnClickListener(v -> pickApp());
+
+        findViewById(R.id.button_set_start).setOnClickListener(v -> pickTime(true));
+        findViewById(R.id.button_set_end).setOnClickListener(v -> pickTime(false));
+        findViewById(R.id.button_start_service).setOnClickListener(v -> {
+            prefs.edit().putStringSet("packages", packages).apply();
+            startService(new Intent(this, LaunchMonitorService.class));
+        });
+
+        updateTimeViews();
+    }
+
+    private void pickApp() {
+        Intent intent = new Intent(Intent.ACTION_MAIN, null);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        startActivityForResult(Intent.createChooser(intent, "Select app"), 1);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == 1 && resultCode == RESULT_OK && data != null) {
+            ComponentName component = data.getComponent();
+            if (component != null) {
+                packages.add(component.getPackageName());
+                adapter.clear();
+                adapter.addAll(packages);
+                adapter.notifyDataSetChanged();
+            }
+        }
+    }
+
+    private void pickTime(boolean start) {
+        int minutes = prefs.getInt(start ? "startMinutes" : "endMinutes", start ? 0 : 23 * 60 + 59);
+        int hour = minutes / 60;
+        int min = minutes % 60;
+        new TimePickerDialog(this, (view, hourOfDay, minute) -> {
+            int m = hourOfDay * 60 + minute;
+            prefs.edit().putInt(start ? "startMinutes" : "endMinutes", m).apply();
+            updateTimeViews();
+        }, hour, min, true).show();
+    }
+
+    private void updateTimeViews() {
+        int startMin = prefs.getInt("startMinutes", 0);
+        int endMin = prefs.getInt("endMinutes", 23 * 60 + 59);
+        startTimeView.setText(String.format(Locale.US, "Start: %02d:%02d", startMin / 60, startMin % 60));
+        endTimeView.setText(String.format(Locale.US, "End: %02d:%02d", endMin / 60, endMin % 60));
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,49 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/start_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start" />
+
+    <Button
+        android:id="@+id/button_set_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Set Start Time" />
+
+    <TextView
+        android:id="@+id/end_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="End" />
+
+    <Button
+        android:id="@+id/button_set_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Set End Time" />
+
+    <Button
+        android:id="@+id/button_add_app"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Add App" />
+
+    <ListView
+        android:id="@+id/app_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/button_start_service"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start Monitoring" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">App Launch Scheduler</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+tasks.register('clean', Delete) {
+    delete rootProject.buildDir
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'AppLaunchScheduler'
+include ':app'


### PR DESCRIPTION
## Summary
- build simple Android app skeleton that lets users pick apps and schedule allowed launch times
- include foreground service to watch current foreground app and redirect when restricted

## Testing
- `gradle assembleDebug --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892e5a6a56883248e1b80ef6823b1f0